### PR TITLE
Added CPF Withdrawal Lock 

### DIFF
--- a/_scams/Money Lock feature: Keeping your money out of scammers’ reach.md
+++ b/_scams/Money Lock feature: Keeping your money out of scammers’ reach.md
@@ -4,4 +4,90 @@ permalink: /scams/moneylock/
 variant: tiptap
 description: ""
 ---
-<div class="isomer-image-wrapper"><img style="width: 100%" height="auto" width="100%" alt="" src="/images/IMG_1064.jpeg"></div><p><strong>Your bank may offer a “Money Locking” feature, which stops scammers from digitally transferring your money out of your bank account. To access money that has been locked up, you need to visit a bank branch to verify your identity or do it through an ATM.&nbsp;&nbsp;</strong></p><p></p><p>Practising cyber hygiene is vital to avoid getting scammed. To guard against scammers, consider “locking up” a portion of the money in your bank accounts.&nbsp;&nbsp;</p><p>The “locked-up” amount cannot be transferred out digitally by anyone, acting as a last line of defence against scammers who try to gain access to your accounts, such as through malware attacks. If you want access to the “locked-up” amount, you may need to visit a bank branch or ATM.</p><p>There may be processing time for unlocking these funds. You should therefore think carefully about how much you should lock. Take stock of your recurring expenses and near-term needs before making your decision.</p><h4>How it works&nbsp;</h4><p>Let’s say you have $5,000 in your bank account but only need $1,000 for your day-to-day or regular expenses. You may “lock up” $4,000, leaving $1,000 that you can use for services such as PayNow, transfers like GIRO payments, NETS transactions or ATM withdrawals.&nbsp;&nbsp;</p><p>Should scammers gain access to your account, the most they can access is the $1,000. They will not be able to spend or transfer out the $4,000 that has been “locked-up”.&nbsp;</p><h4>How to set it up&nbsp;</h4><p>The three local banks, DBS, OCBC, and UOB, offer this “Money Locking” feature.&nbsp;&nbsp;</p><p>Instructions for setting up:&nbsp;</p><ul><li><p>DBS: <a href="https://www.dbs.com.sg/personal/deposits/bank-with-ease/digivault" rel="noopener noreferrer nofollow" target="_blank">Apply for a digiVault account</a> via the Digibank app and transfer the amount you’d like locked. To access your locked funds, visit a DBS bank branch with your NRIC or passport.</p></li><li><p>OCBC: <a href="https://www.ocbc.com/personal-banking/security/secure-banking-ways/ocbc-moneylock.page" rel="noopener noreferrer nofollow" target="_blank">Activate the Money Lock feature</a> feature via the OCBC Digital app or Internet Banking to lock funds in an existing current or savings account. To access your locked funds, visit any OCBC ATM or branch with a valid ATM/debit/credit card and PIN.</p></li><li><p>UOB: <a href="https://www.uob.com.sg/personal/save/lockaway-account.page" rel="noopener noreferrer nofollow" target="_blank">Open a LockAway account</a> via the UOB TMRW app or online and transfer the amount you’d like locked. To access your locked funds, visit a UOB branch with your NRIC or passport.</p></li></ul><h4>Keep safe against scams&nbsp;</h4><p>Avoiding scams starts with adopting good cyber hygiene habits. Follow these rules:&nbsp;</p><p><strong>Secure your devices&nbsp;</strong></p><ul><li><p>Update your devices with the latest security patches&nbsp;</p></li><li><p>Install anti-virus software&nbsp;</p></li><li><p>Only download applications from the official app store&nbsp;</p></li></ul><p><strong>Secure your passwords&nbsp;&nbsp;</strong></p><ul><li><p>Never reveal login credentials, passwords or OTPs to anyone&nbsp;</p></li><li><p>Be cautious of clicking on links; banks will not include clickable links in SMSes or e-mail</p></li></ul><p></p>
+<div class="isomer-image-wrapper">
+<img style="width: 100%" height="auto" width="100%" alt="" src="/images/IMG_1064.jpeg">
+</div>
+<p><strong>Your bank may offer a “Money Locking” feature, which stops scammers from digitally transferring your money out of your bank account. To access money that has been locked up, you need to visit a bank branch to verify your identity or do it through an ATM.&nbsp;&nbsp;</strong>
+</p>
+<p></p>
+<p>Practising cyber hygiene is vital to avoid getting scammed. To guard against
+scammers, consider “locking up” a portion of the money in your bank accounts.&nbsp;&nbsp;</p>
+<p>The “locked-up” amount cannot be transferred out digitally by anyone,
+acting as a last line of defence against scammers who try to gain access
+to your accounts, such as through malware attacks. If you want access to
+the “locked-up” amount, you may need to visit a bank branch or ATM.</p>
+<p>There may be processing time for unlocking these funds. You should therefore
+think carefully about how much you should lock. Take stock of your recurring
+expenses and near-term needs before making your decision.</p>
+<h4>How it works&nbsp;</h4>
+<p>Let’s say you have $5,000 in your bank account but only need $1,000 for
+your day-to-day or regular expenses. You may “lock up” $4,000, leaving
+$1,000 that you can use for services such as PayNow, transfers like GIRO
+payments, NETS transactions or ATM withdrawals.&nbsp;&nbsp;</p>
+<p>Should scammers gain access to your account, the most they can access
+is the $1,000. They will not be able to spend or transfer out the $4,000
+that has been “locked-up”.&nbsp;</p>
+<h4>How to set it up&nbsp;</h4>
+<p>The three local banks, DBS, OCBC, and UOB, offer this “Money Locking”
+feature.&nbsp;&nbsp;</p>
+<p>Instructions for setting up:&nbsp;</p>
+<ul>
+<li>
+<p>DBS: <a href="https://www.dbs.com.sg/personal/deposits/bank-with-ease/digivault" rel="noopener noreferrer nofollow" target="_blank">Apply for a digiVault account</a> via
+the Digibank app and transfer the amount you’d like locked. To access your
+locked funds, visit a DBS bank branch with your NRIC or passport.</p>
+</li>
+<li>
+<p>OCBC: <a href="https://www.ocbc.com/personal-banking/security/secure-banking-ways/ocbc-moneylock.page" rel="noopener noreferrer nofollow" target="_blank">Activate the Money Lock feature</a> feature
+via the OCBC Digital app or Internet Banking to lock funds in an existing
+current or savings account. To access your locked funds, visit any OCBC
+ATM or branch with a valid ATM/debit/credit card and PIN.</p>
+</li>
+<li>
+<p>UOB: <a href="https://www.uob.com.sg/personal/save/lockaway-account.page" rel="noopener noreferrer nofollow" target="_blank">Open a LockAway account</a> via
+the UOB TMRW app or online and transfer the amount you’d like locked. To
+access your locked funds, visit a UOB branch with your NRIC or passport.</p>
+</li>
+</ul>
+<h3>Safeguarding your CPF savings</h3>
+<h3>If you are a CPF member aged 55 or older and have no immediate plans to withdraw your CPF savings, you are encouraged to safeguard your CPF savings by activating the CPF Withdrawal Lock to disable online CPF withdrawals. You can do so via the CPF account settings after logging on to the CPF website using your Singpass. </h3>
+<p>When you need to withdraw your CPF, you can enable online withdrawals
+again via the CPF account settings. For you security, this will be subject
+to Singpass Face Verification and a 12-hour cooling period. Members who
+do not wish to enable online withdrawals again can withdraw in-person at
+CPF Service Centres.</p>
+<p>To safeguard members’ basic retirement adequacy, amounts up to the Basic
+Retirement Sum are automatically reserved for retirement and cannot be
+withdrawn. CPF Board has also introduced a default Daily Withdrawal Limit
+of $2,000 for all members aged 55 or older, as part of a suite of anti-scam
+measures. Members can adjust this limit via the CPF account settings. All
+limit increases are subject to Singpass Face Verification and a 12-hour
+cooling period.</p>
+<h4>Keep safe against scams&nbsp;</h4>
+<p>Avoiding scams starts with adopting good cyber hygiene habits. Follow
+these rules:&nbsp;</p>
+<p><strong>Secure your devices&nbsp;</strong>
+</p>
+<ul>
+<li>
+<p>Update your devices with the latest security patches&nbsp;</p>
+</li>
+<li>
+<p>Install anti-virus software&nbsp;</p>
+</li>
+<li>
+<p>Only download applications from the official app store&nbsp;</p>
+</li>
+</ul>
+<p><strong>Secure your passwords&nbsp;&nbsp;</strong>
+</p>
+<ul>
+<li>
+<p>Never reveal login credentials, passwords or OTPs to anyone&nbsp;</p>
+</li>
+<li>
+<p>Be cautious of clicking on links; banks will not include clickable links
+in SMSes or e-mail</p>
+</li>
+</ul>
+<p></p>

--- a/_scams/Money Lock feature: Keeping your money out of scammers’ reach.md
+++ b/_scams/Money Lock feature: Keeping your money out of scammers’ reach.md
@@ -49,10 +49,14 @@ the UOB TMRW app or online and transfer the amount you’d like locked. To
 access your locked funds, visit a UOB branch with your NRIC or passport.</p>
 </li>
 </ul>
-<h3>Safeguarding your CPF savings</h3>
-<h3>If you are a CPF member aged 55 or older and have no immediate plans to withdraw your CPF savings, you are encouraged to safeguard your CPF savings by activating the CPF Withdrawal Lock to disable online CPF withdrawals. You can do so via the CPF account settings after logging on to the CPF website using your Singpass. </h3>
+<h4>Safeguarding your CPF savings</h4>
+<p>If you are a CPF member aged 55 or older and have no immediate plans to
+withdraw your CPF savings, you are encouraged to safeguard your CPF savings
+by activating the CPF Withdrawal Lock to disable online CPF withdrawals.
+You can do so via the CPF account settings after logging on to the CPF
+website using your Singpass.</p>
 <p>When you need to withdraw your CPF, you can enable online withdrawals
-again via the CPF account settings. For you security, this will be subject
+again via the CPF account settings. For your security, this will be subject
 to Singpass Face Verification and a 12-hour cooling period. Members who
 do not wish to enable online withdrawals again can withdraw in-person at
 CPF Service Centres.</p>


### PR DESCRIPTION
New paras provided by CPFB:

Safeguarding your CPF savings

If you are a CPF member aged 55 or older and have no immediate plans to withdraw your CPF savings, you are encouraged to safeguard your CPF savings by activating the CPF Withdrawal Lock to disable online CPF withdrawals. You can do so via the CPF account settings after logging on to the CPF website using your Singpass.

When you need to withdraw your CPF, you can enable online withdrawals again via the CPF account settings. For your security, this will be subject to Singpass Face Verification and a 12-hour cooling period. Members who do not wish to enable online withdrawals again can withdraw in-person at CPF Service Centres.

To safeguard members’ basic retirement adequacy, amounts up to the Basic Retirement Sum are automatically reserved for retirement and cannot be withdrawn. CPF Board has also introduced a default Daily Withdrawal Limit of $2,000 for all members aged 55 or older, as part of a suite of anti-scam measures. Members can adjust this limit via the CPF account settings. All limit increases are subject to Singpass Face Verification and a 12-hour cooling period.